### PR TITLE
rake task to generate new slide set

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,16 @@ If you want to work on the slides, follow these steps to set it up on your machi
 4. Install the dependencies: `npm install`
 5. Start the development server: `npm start`. This will open http://localhost:8000 in your browser and you can navigate to the slides you want to edit there.
 
+### Generate a new slide set
+
+Use `rake new [slide_name]` to create a new slide set. This will create the needed directory and an initial `index.html` file in `./slides/[slide_name]`, for example:
+
+```shell
+rake new bananas
+```
+
+... which will create `./slides/bananas/index.html` that you can start editing.
+
 ## PDF generation
 
 You can generate PDFs from the HTML slides locally by running decktape, like this:

--- a/Rakefile
+++ b/Rakefile
@@ -1,0 +1,8 @@
+task default: 'new'
+
+task :new, [:name] do |task, args|
+  task_name, slide_name, _rest = ARGV
+  ruby "lib/tasks/new.rb #{slide_name}"
+
+  exit
+end

--- a/lib/tasks/new.rb
+++ b/lib/tasks/new.rb
@@ -1,0 +1,67 @@
+require 'pathname'
+require 'fileutils'
+
+ROOT_PATH = Pathname.new(File.expand_path('../../', File.dirname(__FILE__))).freeze
+SLIDES_DIRECTORY = ROOT_PATH.join('slides').freeze
+TEMPLATE_FILE_NAME = '_template.html'.freeze
+TEMPLATE_FILE_PATH = SLIDES_DIRECTORY.join(TEMPLATE_FILE_NAME).freeze
+INDEX_FILE_NAME = 'index.html'.freeze
+
+def complain_with_error(message)
+  puts
+  puts "*** ERROR: #{message}"
+  puts
+
+  show_help
+
+  exit 1
+end
+
+def complain_with_skip(message)
+  puts "  #{message}, skipping..."
+end
+
+def show_help
+  puts "  Synopsis"
+  puts
+  puts "    rake new slide_name"
+  puts
+end
+
+def slides_directory_path(name)
+  SLIDES_DIRECTORY.join(name)
+end
+
+def slides_index_path(directory)
+  directory.join(INDEX_FILE_NAME)
+end
+
+# read argument
+slide_name = ARGV[0]
+
+complain_with_error('Please provide a slide name') if slide_name.nil?
+
+# create directory
+directory_path = slides_directory_path(slide_name).tap do |path|
+  if path.exist?
+    complain_with_skip("Directory #{path} already exists")
+  else
+    Dir.mkdir(path)
+
+    puts "  Successfully created directory: #{path}"
+  end
+end
+
+# copy template file
+slides_index_path(directory_path).tap do |path|
+  if path.exist?
+    complain_with_skip("Slide #{path} already exists")
+  else
+    FileUtils.cp(TEMPLATE_FILE_PATH, path)
+
+    puts "  Successfully created slides: #{path}"
+  end
+end
+
+puts
+puts "  That's it, have a great day!"


### PR DESCRIPTION
Introduces a simple rake task to setup a new slide set.

Example:

```shell
rake new bananas
```

This copies the `./slides/_template.html` to the (newly created) target directory `./slides/bananas/index.html`. 

Magic. 💥 