### PR TITLE
compile css and js (grunt default) before npm start

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "main": "js/reveal.js",
   "scripts": {
     "test": "grunt test",
-    "start": "grunt serve",
+    "start": "grunt default; grunt serve",
     "build": "grunt"
   },
   "author": {


### PR DESCRIPTION
I realized that changes in the stylesheets are not automatically precompiled if the grunt server is not running. You'd need to start the server first, then modify the styles in order to have the changes in the output and see the effect in the browser, which is a bit confusing...

To avoid this I added `grunt default` (which compiles `css` and `js`) before starting the server.