### PR TITLE
Fix PDF generation in travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,8 @@ node_js:
 - 12
 script:
 - npm start &
-- sleep 2
+- echo "Waiting max 30 seconds to start the server"
+- timeout 30 bash -c -- "until $(curl --output /dev/null --silent --head --fail http://localhost:8000); do printf '.'; sleep 1; done"
 - ./generate-pdfs.sh
 deploy:
   provider: releases

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,8 +3,6 @@ node_js:
 - 12
 script:
 - npm start &
-- echo "Waiting max 30 seconds to start the server"
-- timeout 30 bash -c -- "until $(curl --output /dev/null --silent --head --fail http://localhost:8000); do printf '.'; sleep 1; done"
 - ./generate-pdfs.sh
 deploy:
   provider: releases

--- a/generate-pdfs.sh
+++ b/generate-pdfs.sh
@@ -1,5 +1,40 @@
 #!/usr/bin/env bash
 
+timeout=10
+counter=0
+server_address="http://localhost:8000"
+server_ready="NO"
+
+check_server() {
+  curl --output /dev/null --silent --head --fail ${server_address};
+  exit_code=$?
+
+  if [[ ${exit_code} -eq 0 ]]; then
+    server_ready="YES"
+  fi
+}
+
+echo "Waiting max ${timeout} seconds for the server ('npm start' needs to be running in another session)"
+
+while [[ ${counter} -le ${timeout} ]]; do
+  check_server
+
+  if [[ "${server_ready}" = "YES" ]]; then
+    break
+  fi
+
+  counter=$((counter+1))
+  printf '.'
+  sleep 1
+done
+
+echo ""
+
+if [[ "${server_ready}" != "YES" ]]; then
+  echo "Could not connect to ${server_address}, is 'npm start' running in another session?"
+  exit 9
+fi
+
 for file in slides/**/*.html; do
   slide_name=`echo $file | sed -n -e 's/^slides\/\(.*\)\/index.html/\1/p'`
   `npm bin`/decktape automatic http://localhost:8000/$file $slide_name.pdf


### PR DESCRIPTION
In `.travis.yml` we used to wait for 2 seconds for `npm start` to start until we start the PDF generation.

In PR #10 we introduced `grunt default` being executed before `grunt serve` during `npm start`,
which increases the startup time for `npm start` by a few seconds. So, waiting for 2 seconds were no longer enough and the build started failing.

This PR introduces a timeout mechanism, which is implemented in `./generate-pdfs.sh` directly. It waits max 10 seconds for `http://localhost:8000` to accept connections, else it exits with a useful message.