### PR TITLE
remove colon in argument from `.has_value?(:value)`

### DIFF
--- a/slides/hashes/index.html
+++ b/slides/hashes/index.html
@@ -252,7 +252,7 @@ movie
           <ul>
             <li class="fragment fade-in"><code>.keys</code></li>
             <li class="fragment fade-in"><code>.values</code></li>
-            <li class="fragment fade-in"><code>.key?(:key)</code></li>
+            <li class="fragment fade-in"><code>.key?(key)</code></li>
             <li class="fragment fade-in"><code>.has_value?(value)</code></li></li>
           </ul>
         </section>

--- a/slides/hashes/index.html
+++ b/slides/hashes/index.html
@@ -253,7 +253,7 @@ movie
             <li class="fragment fade-in"><code>.keys</code></li>
             <li class="fragment fade-in"><code>.values</code></li>
             <li class="fragment fade-in"><code>.key?(:key)</code></li>
-            <li class="fragment fade-in"><code>.has_value?(:value)</code></li></li>
+            <li class="fragment fade-in"><code>.has_value?(value)</code></li></li>
           </ul>
         </section>
 


### PR DESCRIPTION
@mischasteiner73 pointed out [here](https://github.com/rubymonstas-zurich/rubymonstas-zurich.github.io/issues/20) that we should change the symbol to a variable in the example

`.has_value?(:value)` to `.has_value?(value)`

I think `.has_value?(value)` is somehow incorrect too, but less incorrect (or at least less confusing)... 😄 

Opinions?