### PR TITLE
add slides for "Standard Library"

### DIFF
--- a/css/theme/rubymonstas.css
+++ b/css/theme/rubymonstas.css
@@ -89,14 +89,301 @@ kbd {
   padding: .2rem .4rem;
   font-size: 0.9em; }
 
-.list-none {
-  list-style-type: none !important; }
-
 .text-red {
   color: #dc402b; }
 
 .text-blue {
   color: #2a76dd; }
+
+.list-none {
+  list-style-type: none !important; }
+
+.list-reset {
+  margin: 0 !important;
+  padding: 0 !important; }
+
+.text-xs {
+  font-size: 0.75rem;
+  line-height: 1rem; }
+
+.text-sm {
+  font-size: 0.875rem;
+  line-height: 1.25rem; }
+
+.text-base {
+  font-size: 1rem;
+  line-height: 1.5rem; }
+
+.text-lg {
+  font-size: 1.125rem;
+  line-height: 1.75rem; }
+
+.text-xl {
+  font-size: 1.25rem;
+  line-height: 1.75rem; }
+
+.text-2xl {
+  font-size: 1.5rem;
+  line-height: 2rem; }
+
+.text-3xl {
+  font-size: 1.875rem;
+  line-height: 2.25rem; }
+
+.text-4xl {
+  font-size: 2.25rem;
+  line-height: 2.5rem; }
+
+.text-5xl {
+  font-size: 3rem;
+  line-height: 1; }
+
+.text-6xl {
+  font-size: 3.75rem;
+  line-height: 1; }
+
+.text-7xl {
+  font-size: 4.5rem;
+  line-height: 1; }
+
+.text-8xl {
+  font-size: 6rem;
+  line-height: 1; }
+
+.text-9xl {
+  font-size: 8rem;
+  line-height: 1; }
+
+.text-white {
+  color: #fff; }
+
+.text-gray-500 {
+  color: #6b7280; }
+
+.text-red-500 {
+  color: #ef4444; }
+
+.text-yellow-500 {
+  color: #fdd34d; }
+
+.text-green-500 {
+  color: #10b981; }
+
+.text-blue-500 {
+  color: #3b82f6; }
+
+.text-indigo-500 {
+  color: #6366f1; }
+
+.text-purple-500 {
+  color: #8b5cf6; }
+
+.text-pink-500 {
+  color: #ec4899; }
+
+.bg-gray-500 {
+  background-color: #6b7280; }
+
+.bg-red-500 {
+  background-color: #ef4444; }
+
+.bg-yellow-500 {
+  background-color: #fdd34d; }
+
+.bg-green-500 {
+  background-color: #10b981; }
+
+.bg-blue-500 {
+  background-color: #3b82f6; }
+
+.bg-indigo-500 {
+  background-color: #6366f1; }
+
+.bg-purple-500 {
+  background-color: #8b5cf6; }
+
+.bg-pink-500 {
+  background-color: #ec4899; }
+
+.border-0 {
+  border-style: solid;
+  border-width: 0px; }
+
+.border {
+  border-style: solid;
+  border-width: 1px; }
+
+.border-3 {
+  border-style: solid;
+  border-width: 3px; }
+
+.border-2 {
+  border-style: solid;
+  border-width: 2px; }
+
+.border-4 {
+  border-style: solid;
+  border-width: 4px; }
+
+.border-8 {
+  border-style: solid;
+  border-width: 8px; }
+
+.border-gray-500 {
+  border-color: #6b7280; }
+
+.border-red-500 {
+  border-color: #ef4444; }
+
+.border-yellow-500 {
+  border-color: #fdd34d; }
+
+.border-green-500 {
+  border-color: #10b981; }
+
+.border-blue-500 {
+  border-color: #3b82f6; }
+
+.border-indigo-500 {
+  border-color: #6366f1; }
+
+.border-purple-500 {
+  border-color: #8b5cf6; }
+
+.border-pink-500 {
+  border-color: #ec4899; }
+
+.m-0 {
+  margin: 0; }
+
+.m-1 {
+  margin: 0.25rem; }
+
+.m-2 {
+  margin: 0.5rem; }
+
+.m-3 {
+  margin: 0.75rem; }
+
+.m-4 {
+  margin: 1rem; }
+
+.m-8 {
+  margin: 2rem; }
+
+.my-0 {
+  margin-top: 0;
+  margin-bottom: 0; }
+
+.my-1 {
+  margin-top: 0.25rem;
+  margin-bottom: 0.25rem; }
+
+.my-2 {
+  margin-top: 0.5rem;
+  margin-bottom: 0.5rem; }
+
+.my-3 {
+  margin-top: 0.75rem;
+  margin-bottom: 0.75rem; }
+
+.my-4 {
+  margin-top: 1rem;
+  margin-bottom: 1rem; }
+
+.my-8 {
+  margin-top: 2rem;
+  margin-bottom: 2rem; }
+
+.mx-0 {
+  margin-left: 0;
+  margin-right: 0; }
+
+.mx-1 {
+  margin-left: 0.25rem;
+  margin-right: 0.25rem; }
+
+.mx-2 {
+  margin-left: 0.5rem;
+  margin-right: 0.5rem; }
+
+.mx-3 {
+  margin-left: 0.75rem;
+  margin-right: 0.75rem; }
+
+.mx-4 {
+  margin-left: 1rem;
+  margin-right: 1rem; }
+
+.mx-8 {
+  margin-left: 2rem;
+  margin-right: 2rem; }
+
+.p-0 {
+  padding: 0; }
+
+.p-1 {
+  padding: 0.25rem; }
+
+.p-2 {
+  padding: 0.5rem; }
+
+.p-3 {
+  padding: 0.75rem; }
+
+.p-4 {
+  padding: 1rem; }
+
+.p-8 {
+  padding: 2rem; }
+
+.py-0 {
+  padding-top: 0;
+  padding-bottom: 0; }
+
+.py-1 {
+  padding-top: 0.25rem;
+  padding-bottom: 0.25rem; }
+
+.py-2 {
+  padding-top: 0.5rem;
+  padding-bottom: 0.5rem; }
+
+.py-3 {
+  padding-top: 0.75rem;
+  padding-bottom: 0.75rem; }
+
+.py-4 {
+  padding-top: 1rem;
+  padding-bottom: 1rem; }
+
+.py-8 {
+  padding-top: 2rem;
+  padding-bottom: 2rem; }
+
+.px-0 {
+  padding-left: 0;
+  padding-right: 0; }
+
+.px-1 {
+  padding-left: 0.25rem;
+  padding-right: 0.25rem; }
+
+.px-2 {
+  padding-left: 0.5rem;
+  padding-right: 0.5rem; }
+
+.px-3 {
+  padding-left: 0.75rem;
+  padding-right: 0.75rem; }
+
+.px-4 {
+  padding-left: 1rem;
+  padding-right: 1rem; }
+
+.px-8 {
+  padding-left: 2rem;
+  padding-right: 2rem; }
 
 /*********************************************
  * GLOBAL STYLES

--- a/css/theme/source/rubymonstas.scss
+++ b/css/theme/source/rubymonstas.scss
@@ -154,11 +154,6 @@ kbd {
   font-size: 0.9em;
 }
 
-
-.list-none {
-  list-style-type: none !important;
-}
-
 .text-red {
   color: #dc402b;
 }
@@ -167,6 +162,135 @@ kbd {
   color: #2a76dd;
 }
 
+.list-none {
+  list-style-type: none !important;
+}
+
+.list-reset {
+  margin: 0 !important;
+  padding: 0 !important;
+}
+
+
+// ----- tailwind-inspired ------
+
+// font sizes
+
+.text-xs { font-size: 0.75rem; line-height: 1rem; }
+.text-sm { font-size: 0.875rem; line-height: 1.25rem; }
+.text-base { font-size: 1rem; line-height: 1.5rem; }
+.text-lg { font-size: 1.125rem; line-height: 1.75rem; }
+.text-xl { font-size: 1.25rem; line-height: 1.75rem; }
+.text-2xl { font-size: 1.5rem; line-height: 2rem; }
+.text-3xl { font-size: 1.875rem; line-height: 2.25rem; }
+.text-4xl { font-size: 2.25rem; line-height: 2.5rem; }
+.text-5xl { font-size: 3rem; line-height: 1; }
+.text-6xl { font-size: 3.75rem; line-height: 1; }
+.text-7xl { font-size: 4.5rem; line-height: 1; }
+.text-8xl { font-size: 6rem; line-height: 1; }
+.text-9xl { font-size: 8rem; line-height: 1; }
+
+// font colors
+
+.text-white { color: #fff; }
+.text-gray-500 { color: rgb(107, 114, 128); }
+.text-red-500 { color: rgb(239, 68, 68); }
+.text-yellow-500 { color: rgb(253, 211, 77); }
+.text-green-500 { color: rgb(16, 185, 129); }
+.text-blue-500 { color: rgb(59, 130, 246); }
+.text-indigo-500 { color: rgb(99, 102, 241); }
+.text-purple-500 { color: rgb(139, 92, 246); }
+.text-pink-500 { color: rgb(236, 72, 153); }
+
+// background colors
+
+.bg-gray-500 { background-color: rgb(107, 114, 128); }
+.bg-red-500 { background-color: rgb(239, 68, 68); }
+.bg-yellow-500 { background-color: rgb(253, 211, 77); }
+.bg-green-500 { background-color: rgb(16, 185, 129); }
+.bg-blue-500 { background-color: rgb(59, 130, 246); }
+.bg-indigo-500 { background-color: rgb(99, 102, 241); }
+.bg-purple-500 { background-color: rgb(139, 92, 246); }
+.bg-pink-500 { background-color: rgb(236, 72, 153); }
+
+// border
+
+.border-0 { border-style: solid; border-width: 0px; }
+.border { border-style: solid; border-width: 1px; }
+.border-3 { border-style: solid; border-width: 3px; }
+.border-2 { border-style: solid; border-width: 2px; }
+.border-4 { border-style: solid; border-width: 4px; }
+.border-8 { border-style: solid; border-width: 8px; }
+
+// border colors
+
+.border-gray-500 { border-color: rgb(107, 114, 128); }
+.border-red-500 { border-color: rgb(239, 68, 68); }
+.border-yellow-500 { border-color: rgb(253, 211, 77); }
+.border-green-500 { border-color: rgb(16, 185, 129); }
+.border-blue-500 { border-color: rgb(59, 130, 246); }
+.border-indigo-500 { border-color: rgb(99, 102, 241); }
+.border-purple-500 { border-color: rgb(139, 92, 246); }
+.border-pink-500 { border-color: rgb(236, 72, 153); }
+
+// margins
+
+.m-0 { margin: 0; }
+.m-1 { margin: 0.25rem; }
+.m-2 { margin: 0.5rem; }
+.m-3 { margin: 0.75rem; }
+.m-4 { margin: 1rem; }
+.m-8 { margin: 2rem; }
+
+// margins y-axis
+
+.my-0 { margin-top: 0; margin-bottom: 0; }
+.my-1 { margin-top: 0.25rem; margin-bottom: 0.25rem; }
+.my-2 { margin-top: 0.5rem; margin-bottom: 0.5rem; }
+.my-3 { margin-top: 0.75rem; margin-bottom: 0.75rem; }
+.my-4 { margin-top: 1rem; margin-bottom: 1rem; }
+.my-8 { margin-top: 2rem; margin-bottom: 2rem; }
+
+// margins x-axis
+
+.mx-0 { margin-left: 0; margin-right: 0; }
+.mx-1 { margin-left: 0.25rem; margin-right: 0.25rem; }
+.mx-2 { margin-left: 0.5rem; margin-right: 0.5rem; }
+.mx-3 { margin-left: 0.75rem; margin-right: 0.75rem; }
+.mx-4 { margin-left: 1rem; margin-right: 1rem; }
+.mx-8 { margin-left: 2rem; margin-right: 2rem; }
+
+// paddings
+
+.p-0 { padding: 0; }
+.p-1 { padding: 0.25rem; }
+.p-2 { padding: 0.5rem; }
+.p-3 { padding: 0.75rem; }
+.p-4 { padding: 1rem; }
+.p-8 { padding: 2rem; }
+
+// paddings y-axis
+
+.py-0 { padding-top: 0; padding-bottom: 0; }
+.py-1 { padding-top: 0.25rem; padding-bottom: 0.25rem; }
+.py-2 { padding-top: 0.5rem; padding-bottom: 0.5rem; }
+.py-3 { padding-top: 0.75rem; padding-bottom: 0.75rem; }
+.py-4 { padding-top: 1rem; padding-bottom: 1rem; }
+.py-8 { padding-top: 2rem; padding-bottom: 2rem; }
+
+// paddings x-axis
+
+.px-0 { padding-left: 0; padding-right: 0; }
+.px-1 { padding-left: 0.25rem; padding-right: 0.25rem; }
+.px-2 { padding-left: 0.5rem; padding-right: 0.5rem; }
+.px-3 { padding-left: 0.75rem; padding-right: 0.75rem; }
+.px-4 { padding-left: 1rem; padding-right: 1rem; }
+.px-8 { padding-left: 2rem; padding-right: 2rem; }
+
 // Theme template ------------------------------
 @import "../template/theme";
 // ---------------------------------------------
+
+
+
+

--- a/slides/ruby-standard-library/index.html
+++ b/slides/ruby-standard-library/index.html
@@ -66,11 +66,16 @@
 
         <section>
           <h2>Contents / Purpose</h2>
-          <ul class="list-reset">
-            <li class="fragment fade-in">More complex features than Ruby Core</li>
-            <li class="fragment fade-in"><i>"Batteries included"</i></li>
-            <li class="fragment fade-in">Sometimes a bit dated, but very solid</li>
-          </ul>
+          <div class="fragment fade-in">
+            The <b>Ruby Standard Library</b> is an extensive set of advanced tools.
+          </div>
+          <div class="fragment fade-in my-8">
+            These tools provide functionalities for common problems.
+            <div class="text-2xl">We'll see examples later</div>
+          </div>
+          <div class="fragment fade-in">
+            The Library is <b>built-in</b>, so we don't have to install anything.
+          </div>
         </section>
 
         <section>

--- a/slides/ruby-standard-library/index.html
+++ b/slides/ruby-standard-library/index.html
@@ -1,0 +1,139 @@
+<!doctype html>
+<html>
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no">
+
+    <title>RM - Ruby Standard Library</title>
+
+    <link rel="stylesheet" href="../../css/reset.css">
+    <link rel="stylesheet" href="../../css/reveal.css">
+    <link rel="stylesheet" href="../../css/theme/rubymonstas.css">
+
+    <!-- Theme used for syntax highlighting of code -->
+    <link rel="stylesheet" href="../../lib/css/solarized.css">
+
+    <!-- Printing and PDF exports -->
+    <script>
+      var link = document.createElement( 'link' );
+      link.rel = 'stylesheet';
+      link.type = 'text/css';
+      link.href = window.location.search.match( /print-pdf/gi ) ? '../../css/print/pdf.css' : '../../css/print/paper.css';
+      document.getElementsByTagName( 'head' )[0].appendChild( link );
+    </script>
+  </head>
+  <body>
+    <div class="reveal">
+      <div class="slides">
+        <!-- Title slide with the topic. Don't forget to change the <title> tag too! -->
+        <section>
+          <div class="flex-container">
+            <div class="flex-column text-align-left">
+              <h1>Ruby Monstas</h1>
+              <hr>
+              <p class='subtitle'>
+                The Ruby Standard Library
+              </p>
+            </div>
+            <div class="flex-column-200px">
+              <img class="no-border" src="../images/logo-cropped-small.png">
+            </div>
+          </div>
+          <aside class="notes">
+            <p>You can write your presenter notes here</p>
+            <p>You start the presenter mode by pressing <kbd>S</kbd>.</p>
+            <p>By pressing <kbd>O</kbd> you'll see the slides overview.</p>
+          </aside>
+        </section>
+
+
+        <section>
+          <h2>The Ruby Distribution</h2>
+          <ul class="list-none list-reset">
+            <li class="border-4 border-red-500 p-4">
+              <ul class="list-none list-reset">
+                <li class="border-4 border-red-500 my-4 p-4 bg-yellow-500">
+                  <b>Ruby Standard Library</b>
+                  <div class="text-2xl">More advanced Classes/Features</div>
+                </li>
+                <li class="border-4 border-red-500 my-4 p-4">
+                  <b>Ruby Core</b>
+                  <div class="text-2xl">Strings, Symbols, Array, Hashes, ...</div>
+                </li>
+                <li class="border-4 border-red-500 my-4 p-4">
+                  <b>Ruby Language</b>
+                  <div class="text-2xl">Syntax</div>
+                </li>
+              </ul>
+            </li>
+          </ul>
+        </section>
+
+        <section>
+          <h2>Contents / Purpose</h2>
+          <ul class="list-reset">
+            <li class="fragment fade-in">More complex features than Ruby Core</li>
+            <li class="fragment fade-in"><i>"Batteries included"</i></li>
+            <li class="fragment fade-in">Sometimes a bit dated, but very solid</li>
+          </ul>
+        </section>
+
+        <section>
+          <h2>Examples</h2>
+          <ul class="list-reset">
+            <li class="fragment fade-in my-4">
+              <b>Networking</b>
+              <div class="text-2xl">Web, E-Mail, Sockets, ...</div>
+            </li>
+            <li class="fragment fade-in my-4">
+              <b>Advanced Math</b>
+              <div class="text-2xl">Prime number generator, Matrices, Complex numbers, ...</div>
+            </li>
+            <li class="fragment fade-in my-4">
+              <b>Date format libraries</b>
+              <div class="text-2xl">JSON, XML, YAML, RSS, ...</div>
+            </li>
+            <li class="fragment fade-in my-4">
+              <b>Many, many more</b>
+              <div class="text-2xl">
+                Date/Time, Simple Databases, Cryptography, Advanced Data Structures, <br/>
+                Debugging, Profiling, Introspection, ...</div>
+            </li>
+          </ul>
+        </section>
+
+        <!-- Links to the relevant chapters in Ruby For Beginners -->
+        <section>
+          <h2>Additional Resources</h2>
+
+          <ul class="list-reset">
+            <li><a href="https://ruby-doc.org/core/">Ruby Core Documentation</a></li>
+            <li><a href="https://ruby-doc.org/stdlib/">Ruby Standard Library Documentation</a></li>
+          </ul>
+        </section>
+
+        <!-- Last slide is the question for questions ;P -->
+        <section>
+          <p>What <b>questions</b> do you have?</p>
+        </section>
+     </div>
+    </div>
+
+    <script src="../../js/reveal.js"></script>
+
+    <script>
+      // More info about config & dependencies:
+      // - https://github.com/hakimel/reveal.js#configuration
+      // - https://github.com/hakimel/reveal.js#dependencies
+      Reveal.initialize({
+        pdfSeparateFragments: false,
+        dependencies: [
+          { src: '../../plugin/markdown/marked.js' },
+          { src: '../../plugin/markdown/markdown.js' },
+          { src: '../../plugin/notes/notes.js', async: true },
+          { src: '../../plugin/highlight/highlight.js', async: true }
+        ]
+      });
+    </script>
+  </body>
+</html>

--- a/slides/ruby-standard-library/index.html
+++ b/slides/ruby-standard-library/index.html
@@ -90,7 +90,7 @@
               <div class="text-2xl">Prime number generator, Matrices, Complex numbers, ...</div>
             </li>
             <li class="fragment fade-in my-4">
-              <b>Date format libraries</b>
+              <b>Data format libraries</b>
               <div class="text-2xl">JSON, XML, YAML, RSS, ...</div>
             </li>
             <li class="fragment fade-in my-4">

--- a/slides/ruby-standard-library/index.html
+++ b/slides/ruby-standard-library/index.html
@@ -39,11 +39,6 @@
               <img class="no-border" src="../images/logo-cropped-small.png">
             </div>
           </div>
-          <aside class="notes">
-            <p>You can write your presenter notes here</p>
-            <p>You start the presenter mode by pressing <kbd>S</kbd>.</p>
-            <p>By pressing <kbd>O</kbd> you'll see the slides overview.</p>
-          </aside>
         </section>
 
 

--- a/slides/ruby-standard-library/index.html
+++ b/slides/ruby-standard-library/index.html
@@ -79,7 +79,35 @@
         </section>
 
         <section>
-          <h2>Examples</h2>
+          <h2>Example - SecureRandom</h2>
+          <div class="my-8">
+            <pre><code class="hljs ruby">require 'securerandom'
+
+SecureRandom.alphanumeric(15)       # => FvUMIA00NVLijK0
+SecureRandom.random_number(1..1000) # => 795
+SecureRandom.hex(10)                # => 664bd09321b3ae235fb3</code></pre>
+          </div>
+          <a href="https://ruby-doc.org/stdlib/libdoc/securerandom/rdoc/SecureRandom.html" class="text-lg">https://ruby-doc.org/stdlib/libdoc/securerandom/rdoc/SecureRandom.html</a>
+        </section>
+
+        <section>
+          <h2>Example - Time</h2>
+          <div class="my-8">
+            <pre><code class="hljs ruby">require 'time'
+
+firework_start = Time.parse("2020-12-31 23:59:59")
+firework_end = Time.parse("2021-01-01 00:09:59")
+
+seconds = firework_end - firework_start # => 600.0
+
+firework_start.strftime("%A") # => Thursday
+firework_end.strftime("%A")   # => Friday</code></pre>
+          </div>
+          <a href="https://ruby-doc.org/stdlib/libdoc/time/rdoc/Time.html" class="text-lg">https://ruby-doc.org/stdlib/libdoc/time/rdoc/Time.html</a>
+        </section>
+
+        <section>
+          <h2>More libraries</h2>
           <ul class="list-reset">
             <li class="fragment fade-in my-4">
               <b>Networking</b>
@@ -91,7 +119,7 @@
             </li>
             <li class="fragment fade-in my-4">
               <b>Data format libraries</b>
-              <div class="text-2xl">JSON, XML, YAML, RSS, ...</div>
+              <div class="text-2xl">CSV, JSON, XML, YAML, RSS, ...</div>
             </li>
             <li class="fragment fade-in my-4">
               <b>Many, many more</b>


### PR DESCRIPTION
I borrowed some utilities from TailwindCSS in order to achieve this.

![Screenshot 2020-11-30 at 20 19 42](https://user-images.githubusercontent.com/1409672/100654501-31246f80-334a-11eb-9600-77eca97cf135.png)

I liked the result, that's why I added even some more Tailwind CSS classes even though I don't use them (but they're pretty handy).

Also, I decided to put all stdlib examples on 1 slide instead of multiple, what do you think?

![Screenshot 2020-11-30 at 20 19 51](https://user-images.githubusercontent.com/1409672/100654703-819bcd00-334a-11eb-9600-50af68ca09e2.png)

