### PR TITLE
Create releases only after merging pull requests

### DIFF
--- a/.github/workflows/generate-pdfs.yml
+++ b/.github/workflows/generate-pdfs.yml
@@ -31,6 +31,7 @@ jobs:
     - run: ./generate-pdfs.sh
 
     - name: Create Release
+      if: {{ github.ref == 'ref/head/master' }}
       id: create_release
       uses: actions/create-release@v1
       env:
@@ -42,6 +43,7 @@ jobs:
         prerelease: false
         
     - name: Upload release assets
+      if: {{ github.ref == 'ref/head/master' }}
       uses: actions/github-script@v3
       with:
         github-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
When Dependabot opens a pull request GitHub Actions run with read-only
permissions:

https://github.blog/changelog/2021-02-19-github-actions-workflows-triggered-by-dependabot-prs-will-run-with-read-only-permissions/

This makes the "create release" build step fail.

It's possible to opt-in to to write permissions, but I have still to
carefully read and try to understand the security implications. See
https://securitylab.github.com/research/github-actions-preventing-pwn-requests/

Instead, we can skip the release creation and artifact upload steps if
the workflow is not running on the main branch. In my opinion, it's
enough to know that hte PDFs are built successfully.

Only human contributors can merge, because the new version of dependabot
integrated in GitHub explicitly does not support automatic merging upon
approval. I assume that means the workflow will run with sufficient
privileges on the main branch.