### PR TITLE
change if-syntax for GH Action

### DIFF
--- a/.github/workflows/generate-pdfs.yml
+++ b/.github/workflows/generate-pdfs.yml
@@ -18,12 +18,12 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
-   
+
     - name: Use Node.js ${{ matrix.node-version }}
       uses: actions/setup-node@v1
       with:
         node-version: ${{ matrix.node-version }}
-    
+
     - run: npm install
 
     - run: npm start &
@@ -31,7 +31,7 @@ jobs:
     - run: ./generate-pdfs.sh
 
     - name: Create Release
-      if: {{ github.ref == 'ref/head/master' }}
+      if: ${{ github.ref == 'ref/head/master' }}
       id: create_release
       uses: actions/create-release@v1
       env:
@@ -41,9 +41,9 @@ jobs:
         release_name: Release ${{ github.sha }}
         draft: false
         prerelease: false
-        
+
     - name: Upload release assets
-      if: {{ github.ref == 'ref/head/master' }}
+      if: ${{ github.ref == 'ref/head/master' }}
       uses: actions/github-script@v3
       with:
         github-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
I noticed the GH action `generate-pdfs.yml` failed due to a syntax error in the workflow file:

![Screenshot 2021-08-09 at 20 37 52](https://user-images.githubusercontent.com/1409672/128756982-262d1675-3667-4f1d-8a44-1c1f633c261e.png)

I presume they changed the syntax at some point.